### PR TITLE
Add docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM python:3.11-slim
+
+# Run privileged commands as root
+USER root
+
+# Install dependencies
+RUN apt-get update
+RUN apt-get install -y curl build-essential
+RUN pip install uv
+
+# Install Node.js and npm
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh
+RUN bash nodesource_setup.sh
+RUN apt-get install -y nodejs
+
+# Install Claude CLI
+RUN npm install -g @anthropic-ai/claude-code
+
+# Add work user
+RUN useradd -ms /bin/bash work
+
+# Set work directory
+WORKDIR /home/work/app
+
+# Copy project files
+COPY . /home/work/app
+RUN chown -R work:work /home/work/app
+
+# Switch to work user
+USER work
+
+# Install Python dependencies
+RUN uv sync
+RUN uv pip install -e .
+RUN uv add requests
+
+# Expose API port
+EXPOSE 8000
+
+# Start API server in production mode
+CMD ["uv", "run", "uvicorn", "claude_code_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Use the Makefile to install the project or pip/uv.
 
 ![Roo Code chat](assets/roo_code.png) 
 
+### Dockerized Usage
+```bash
+docker compose up
+```
+
+The docker compose setup mounts the current user's claude directory as read-only for a zero configuration setup.
+
 ### Python Implementation
 ```bash
 # Clone and setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  claude-code-api:
+    build: .
+    container_name: claude-code-api
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      - PROJECT_ROOT=/home/work/projects
+    volumes:
+      - ./projects:/home/work/projects:rw
+      - $HOME/.claude:/home/work/.claude:ro


### PR DESCRIPTION
This adds a simple docker setup using python:3.11-slim.

Claude configuration from user is mounted in read-only mode.
The application runs as user "work", only dependencies are installed as root when building the image.