### PR TITLE
fix: add explicit greenlet dependency for SQLAlchemy async support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "python-multipart>=0.0.6",
     "pydantic-settings>=2.1.0",
     "sqlalchemy>=2.0.23",
+    "greenlet>=3.0.0",
     "aiosqlite>=0.19.0",
     "alembic>=1.13.0",
     "passlib[bcrypt]>=1.7.4",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "python-multipart>=0.0.6",
         "pydantic-settings>=2.1.0",
         "sqlalchemy>=2.0.23",
+        "greenlet>=3.0.0",
         "aiosqlite>=0.19.0",
         "alembic>=1.13.0",
         "passlib[bcrypt]>=1.7.4",


### PR DESCRIPTION
## Summary
- Add `greenlet>=3.0.0` as an explicit dependency in `pyproject.toml`

## Problem
SQLAlchemy's async features (used with `aiosqlite`) require `greenlet` at runtime, but it's not always installed as a transitive dependency. This caused `make start` to fail on macOS with a missing module error.

## Test plan
- [x] `make start` runs without import errors on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies: added greenlet (>=3.0.0) to ensure compatibility with recent environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->