### PR TITLE
docs: link bug reports to central discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Common settings are in `claude_code_api/core/config.py`:
 - `database_url`
 - `require_auth`
 
+## Bug Reports & Support
+
+For `claude-code-api` and `ai-code-fusion`, use this discussion thread for bug reports and troubleshooting:
+
+- https://github.com/codingworkflow/ai-code-fusion/discussions/151
+
 ## Developer Docs
 
 For engineering workflows and internal commands:


### PR DESCRIPTION
Adds a README section routing bug reports and issue triage to the shared discussion thread:\n\n- https://github.com/codingworkflow/ai-code-fusion/discussions/151\n\nThis centralizes intake for both claude-code-api and ai-code-fusion.